### PR TITLE
Feature/issue 2 add dark mode

### DIFF
--- a/task_nest/lib/components/theme_button.dart
+++ b/task_nest/lib/components/theme_button.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class ThemeButton extends StatelessWidget {
+  final Function changeThemeMode;
+
+  const ThemeButton({
+    super.key,
+    required this.changeThemeMode,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isBriget = Theme.of(context).brightness == Brightness.light;
+
+    return IconButton(
+      tooltip: isBriget ? 'use dark mode' : 'use ligt mode',
+      icon: isBriget
+          ? const Icon(Icons.dark_mode_outlined)
+          : const Icon(Icons.light_mode_outlined),
+      onPressed: () => changeThemeMode(!isBriget), 
+    );
+  }
+}

--- a/task_nest/lib/components/theme_button.dart
+++ b/task_nest/lib/components/theme_button.dart
@@ -13,7 +13,7 @@ class ThemeButton extends StatelessWidget {
     final isBriget = Theme.of(context).brightness == Brightness.light;
 
     return IconButton(
-      tooltip: isBriget ? 'use dark mode' : 'use ligt mode',
+      tooltip: isBriget ? 'use dark theme' : 'use ligt theme',
       icon: isBriget
           ? const Icon(Icons.dark_mode_outlined)
           : const Icon(Icons.light_mode_outlined),

--- a/task_nest/lib/main.dart
+++ b/task_nest/lib/main.dart
@@ -16,7 +16,7 @@ class TaskNest extends StatefulWidget {
 class _TaskNestState extends State<TaskNest> {
   // This widget is the root of your application.
   ThemeMode themeMode = ThemeMode.light; // default theme
-  Color colorSelected = Colors.pink;
+  Color colorSelected = Colors.white; // default app color
 
   void changeThemeMode(bool useLightMode) {
     setState(() {
@@ -46,6 +46,7 @@ class _TaskNestState extends State<TaskNest> {
       home: Home(
         changeTheme: changeThemeMode,
         colorSelected: colorSelected,
+        isLightMode: themeMode == ThemeMode.light,
       ),
     );
   }

--- a/task_nest/lib/main.dart
+++ b/task_nest/lib/main.dart
@@ -7,13 +7,13 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     SystemChrome.setSystemUIOverlayStyle(
-        SystemUiOverlayStyle(statusBarColor: Colors.transparent));
+        const SystemUiOverlayStyle(statusBarColor: Colors.transparent));
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'ToDo App',

--- a/task_nest/lib/main.dart
+++ b/task_nest/lib/main.dart
@@ -15,14 +15,38 @@ class TaskNest extends StatefulWidget {
 
 class _TaskNestState extends State<TaskNest> {
   // This widget is the root of your application.
+  ThemeMode themeMode = ThemeMode.light; // default theme
+  Color colorSelected = Colors.pink;
+
+  void changeThemeMode(bool useLightMode) {
+    setState(() {
+      themeMode = useLightMode ? ThemeMode.light : ThemeMode.dark;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     SystemChrome.setSystemUIOverlayStyle(
         const SystemUiOverlayStyle(statusBarColor: Colors.transparent));
+
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'ToDo App',
-      home: Home(),
+      themeMode: themeMode,
+      theme: ThemeData(
+        colorSchemeSeed: colorSelected,
+        useMaterial3: true,
+        brightness: Brightness.light,
+      ),
+      darkTheme: ThemeData(
+        colorSchemeSeed: colorSelected,
+        useMaterial3: true,
+        brightness: Brightness.dark,
+      ),
+      home: Home(
+        changeTheme: changeThemeMode,
+        colorSelected: colorSelected,
+      ),
     );
   }
 }

--- a/task_nest/lib/main.dart
+++ b/task_nest/lib/main.dart
@@ -3,12 +3,17 @@ import 'package:flutter/services.dart';
 import './screens/home.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const TaskNest());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class TaskNest extends StatefulWidget {
+  const TaskNest({super.key});
 
+  @override
+  State<TaskNest> createState() => _TaskNestState();
+}
+
+class _TaskNestState extends State<TaskNest> {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {

--- a/task_nest/lib/screens/home.dart
+++ b/task_nest/lib/screens/home.dart
@@ -32,7 +32,7 @@ class _HomeState extends State<Home> {
       body: Stack(
         children: [
           Container(
-            padding: EdgeInsets.symmetric(
+            padding: const EdgeInsets.symmetric(
               horizontal: 20,
               vertical: 15,
             ),
@@ -43,11 +43,11 @@ class _HomeState extends State<Home> {
                   child: ListView(
                     children: [
                       Container(
-                        margin: EdgeInsets.only(
+                        margin: const EdgeInsets.only(
                           top: 50,
                           bottom: 20,
                         ),
-                        child: Text(
+                        child: const Text(
                           'All ToDos',
                           style: TextStyle(
                             fontSize: 30,
@@ -58,8 +58,7 @@ class _HomeState extends State<Home> {
                       if (_notFoundMessage.isNotEmpty)
                         Text(
                           _notFoundMessage,
-                          style:
-                              TextStyle(color: Colors.red),
+                          style: const TextStyle(color: Colors.red),
                         ),
                       for (ToDo todoo in _foundToDo.reversed)
                         ToDoItem(
@@ -78,12 +77,12 @@ class _HomeState extends State<Home> {
             child: Row(children: [
               Expanded(
                 child: Container(
-                  margin: EdgeInsets.only(
+                  margin: const EdgeInsets.only(
                     bottom: 20,
                     right: 20,
                     left: 20,
                   ),
-                  padding: EdgeInsets.symmetric(
+                  padding: const EdgeInsets.symmetric(
                     horizontal: 20,
                     vertical: 5,
                   ),
@@ -101,24 +100,18 @@ class _HomeState extends State<Home> {
                   ),
                   child: TextField(
                     controller: _todoController,
-                    decoration: InputDecoration(
+                    decoration: const InputDecoration(
                         hintText: 'Add a new todo item',
                         border: InputBorder.none),
                   ),
                 ),
               ),
               Container(
-                margin: EdgeInsets.only(
+                margin: const EdgeInsets.only(
                   bottom: 20,
                   right: 20,
                 ),
                 child: ElevatedButton(
-                  child: Text(
-                    '+',
-                    style: TextStyle(
-                      fontSize: 40,
-                    ),
-                  ),
                   onPressed: () {
                     _addToDoItem(_todoController.text);
                   },
@@ -126,6 +119,12 @@ class _HomeState extends State<Home> {
                     //primary: tdBlue,
                     minimumSize: Size(60, 60),
                     elevation: 10,
+                  ),
+                  child: const Text(
+                    '+',
+                    style: TextStyle(
+                      fontSize: 40,
+                    ),
                   ),
                 ),
               ),
@@ -179,21 +178,20 @@ class _HomeState extends State<Home> {
 
     setState(() {
       _foundToDo = results;
-      _notFoundMessage =
-          message;
+      _notFoundMessage = message;
     });
   }
 
   Widget searchBox() {
     return Container(
-      padding: EdgeInsets.symmetric(horizontal: 15),
+      padding: const EdgeInsets.symmetric(horizontal: 15),
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(20),
       ),
       child: TextField(
         onChanged: (value) => _runFilter(value),
-        decoration: InputDecoration(
+        decoration: const InputDecoration(
           contentPadding: EdgeInsets.all(0),
           prefixIcon: Icon(
             Icons.search,
@@ -216,20 +214,22 @@ class _HomeState extends State<Home> {
     return AppBar(
       backgroundColor: tdBGColor,
       elevation: 0,
-      title: Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-        Icon(
-          Icons.menu,
-          color: tdBlack,
-          size: 30,
-        ),
-        Container(
-          height: 40,
-          width: 40,
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(20),
-            child: Image.asset('assets/images/cifer.png'),
+      title: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween, 
+        children: [
+          const Icon(
+            Icons.menu,
+            color: tdBlack,
+            size: 30,
           ),
-        ),
+          Container(
+            height: 40,
+            width: 40,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(20),
+              child: Image.asset('assets/images/cifer.png'),
+            ),
+          ),
       ]),
     );
   }

--- a/task_nest/lib/screens/home.dart
+++ b/task_nest/lib/screens/home.dart
@@ -2,19 +2,20 @@ import 'package:flutter/material.dart';
 import 'package:task_nest/components/theme_button.dart';
 
 import '../model/todo.dart';
-import '../constants/colors.dart';
 import '../widgets/todo_item.dart';
 
-String _notFoundMessage = "";
+String _notFoundMessage = ""; // the message to be returned when search matches no existing todo
 
 class Home extends StatefulWidget {
   final void Function(bool useLightMode) changeTheme;
   final Color colorSelected;
+  final bool isLightMode;
 
   const Home({
     super.key,
     required this.changeTheme,
     required this.colorSelected,
+    required this.isLightMode,
   });
 
   @override
@@ -34,6 +35,10 @@ class _HomeState extends State<Home> {
 
   @override
   Widget build(BuildContext context) {
+    final textTheme = Theme.of(context)
+        .textTheme
+        .apply(displayColor: Theme.of(context).colorScheme.onSurface);
+
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: _buildAppBar(),
@@ -64,9 +69,11 @@ class _HomeState extends State<Home> {
                         ),
                       ),
                       if (_notFoundMessage.isNotEmpty)
-                        Text(
-                          _notFoundMessage,
-                          style: const TextStyle(color: Colors.red),
+                        Center(
+                          child:  Text(
+                            _notFoundMessage,
+                            style: textTheme.titleLarge,
+                          ),
                         ),
                       for (ToDo todoo in _foundToDo.reversed)
                         ToDoItem(
@@ -84,35 +91,19 @@ class _HomeState extends State<Home> {
             alignment: Alignment.bottomCenter,
             child: Row(children: [
               Expanded(
-                child: Container(
-                  margin: const EdgeInsets.only(
-                    bottom: 20,
-                    right: 20,
-                    left: 20,
-                  ),
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 20,
-                    vertical: 5,
-                  ),
-                  decoration: BoxDecoration(
-                    //color: widget.colorSelected,
-                    //boxShadow: const [
-                     // BoxShadow(
-                        //color: Colors.grey,
-                     //   offset: Offset(0.0, 0.0),
-                     //   blurRadius: 10.0,
-                     //   spreadRadius: 0.0,
-                      //),
-                    //],
-                    borderRadius: BorderRadius.circular(10),
+                child: Card(
+                  elevation: 10.0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10.0),
                   ),
                   child: TextField(
-                    
                     controller: _todoController,
                     decoration: const InputDecoration(
-                        hintText: 'Add a new todo item',
-                        border: InputBorder.none),
-                  ),
+                      hintText: 'Add a new todo item',
+                      border: InputBorder.none,
+                      contentPadding: EdgeInsets.all(16.0)
+                    ),
+                  )
                 ),
               ),
               Container(
@@ -125,9 +116,8 @@ class _HomeState extends State<Home> {
                     _addToDoItem(_todoController.text);
                   },
                   style: ElevatedButton.styleFrom(
-                    //primary: tdBlue,
-                    minimumSize: Size(60, 60),
-                    elevation: 10,
+                    minimumSize: const Size(60, 60),
+                    elevation: 10.0,
                   ),
                   child: const Text(
                     '+',
@@ -182,7 +172,7 @@ class _HomeState extends State<Home> {
 
     // Check if results are empty and set the message
     if (results.isEmpty) {
-      message = "Todo does not exist";
+      message = "Todo not found";
     }
 
     setState(() {
@@ -192,47 +182,39 @@ class _HomeState extends State<Home> {
   }
 
   Widget searchBox() {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 15),
-      decoration: BoxDecoration(
-        color: widget.colorSelected,
-        borderRadius: BorderRadius.circular(20),
+    return Card(
+      elevation: 2.0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(10.0),
       ),
       child: TextField(
         onChanged: (value) => _runFilter(value),
         decoration: const InputDecoration(
-          contentPadding: EdgeInsets.all(0),
-          prefixIcon: Icon(
-            Icons.search,
-            color: tdBlack,
-            size: 20,
-          ),
-          prefixIconConstraints: BoxConstraints(
-            maxHeight: 20,
-            minWidth: 25,
-          ),
+          hintText: 'Search...',
           border: InputBorder.none,
-          hintText: 'Search',
-          hintStyle: TextStyle(color: tdGrey),
+          contentPadding: EdgeInsets.all(16.0),
+          prefixIcon: Icon(Icons.search),
         ),
-      ),
+      )
     );
+    
   }
 
   AppBar _buildAppBar() {
     return AppBar(
-      //backgroundColor: tdBGColor,
-      elevation: 0,
+    backgroundColor: Theme.of(context).colorScheme.surface,
+      elevation: 4.0,
       title: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           const Icon(
             Icons.menu,
-            color: tdBlack,
             size: 30,
           ),
-          ThemeButton(changeThemeMode: widget.changeTheme),
-          Container(
+          ThemeButton(
+            changeThemeMode: widget.changeTheme
+          ),
+          SizedBox(
             height: 40,
             width: 40,
             child: ClipRRect(

--- a/task_nest/lib/screens/home.dart
+++ b/task_nest/lib/screens/home.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:task_nest/components/theme_button.dart';
 
 import '../model/todo.dart';
 import '../constants/colors.dart';
@@ -7,7 +8,14 @@ import '../widgets/todo_item.dart';
 String _notFoundMessage = "";
 
 class Home extends StatefulWidget {
-  Home({Key? key}) : super(key: key);
+  final void Function(bool useLightMode) changeTheme;
+  final Color colorSelected;
+
+  const Home({
+    super.key,
+    required this.changeTheme,
+    required this.colorSelected,
+  });
 
   @override
   State<Home> createState() => _HomeState();
@@ -27,7 +35,7 @@ class _HomeState extends State<Home> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: tdBGColor,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: _buildAppBar(),
       body: Stack(
         children: [
@@ -87,18 +95,19 @@ class _HomeState extends State<Home> {
                     vertical: 5,
                   ),
                   decoration: BoxDecoration(
-                    color: Colors.white,
-                    boxShadow: const [
-                      BoxShadow(
-                        color: Colors.grey,
-                        offset: Offset(0.0, 0.0),
-                        blurRadius: 10.0,
-                        spreadRadius: 0.0,
-                      ),
-                    ],
+                    //color: widget.colorSelected,
+                    //boxShadow: const [
+                     // BoxShadow(
+                        //color: Colors.grey,
+                     //   offset: Offset(0.0, 0.0),
+                     //   blurRadius: 10.0,
+                     //   spreadRadius: 0.0,
+                      //),
+                    //],
                     borderRadius: BorderRadius.circular(10),
                   ),
                   child: TextField(
+                    
                     controller: _todoController,
                     decoration: const InputDecoration(
                         hintText: 'Add a new todo item',
@@ -186,7 +195,7 @@ class _HomeState extends State<Home> {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 15),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: widget.colorSelected,
         borderRadius: BorderRadius.circular(20),
       ),
       child: TextField(
@@ -212,16 +221,17 @@ class _HomeState extends State<Home> {
 
   AppBar _buildAppBar() {
     return AppBar(
-      backgroundColor: tdBGColor,
+      //backgroundColor: tdBGColor,
       elevation: 0,
       title: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween, 
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           const Icon(
             Icons.menu,
             color: tdBlack,
             size: 30,
           ),
+          ThemeButton(changeThemeMode: widget.changeTheme),
           Container(
             height: 40,
             width: 40,
@@ -230,7 +240,8 @@ class _HomeState extends State<Home> {
               child: Image.asset('assets/images/cifer.png'),
             ),
           ),
-      ]),
+        ],
+      ),
     );
   }
 }

--- a/task_nest/lib/widgets/todo_item.dart
+++ b/task_nest/lib/widgets/todo_item.dart
@@ -5,20 +5,20 @@ import '../constants/colors.dart';
 
 class ToDoItem extends StatelessWidget {
   final ToDo todo;
-  final onToDoChanged;
-  final onDeleteItem;
+  final Function onToDoChanged;
+  final Function onDeleteItem;
 
   const ToDoItem({
-    Key? key,
+    super.key,
     required this.todo,
     required this.onToDoChanged,
     required this.onDeleteItem,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: EdgeInsets.only(bottom: 20),
+      margin: const EdgeInsets.only(bottom: 20),
       child: ListTile(
         onTap: () {
           // print('Clicked on Todo Item.');
@@ -27,7 +27,7 @@ class ToDoItem extends StatelessWidget {
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(20),
         ),
-        contentPadding: EdgeInsets.symmetric(horizontal: 20, vertical: 5),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
         tileColor: Colors.white,
         leading: Icon(
           todo.isDone ? Icons.check_box : Icons.check_box_outline_blank,
@@ -42,8 +42,8 @@ class ToDoItem extends StatelessWidget {
           ),
         ),
         trailing: Container(
-          padding: EdgeInsets.all(0),
-          margin: EdgeInsets.symmetric(vertical: 12),
+          padding: const EdgeInsets.all(0),
+          margin: const EdgeInsets.symmetric(vertical: 12),
           height: 35,
           width: 35,
           decoration: BoxDecoration(
@@ -53,7 +53,7 @@ class ToDoItem extends StatelessWidget {
           child: IconButton(
             color: Colors.white,
             iconSize: 18,
-            icon: Icon(Icons.delete),
+            icon: const Icon(Icons.delete),
             onPressed: () {
               // print('Clicked on delete icon');
               onDeleteItem(todo.id);

--- a/task_nest/lib/widgets/todo_item.dart
+++ b/task_nest/lib/widgets/todo_item.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import '../model/todo.dart';
-import '../constants/colors.dart';
 
 class ToDoItem extends StatelessWidget {
   final ToDo todo;
@@ -17,27 +16,24 @@ class ToDoItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return Card(
+      elevation: 4.0,
       margin: const EdgeInsets.only(bottom: 20),
       child: ListTile(
         onTap: () {
-          // print('Clicked on Todo Item.');
           onToDoChanged(todo);
         },
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(20),
         ),
         contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 5),
-        tileColor: Colors.white,
         leading: Icon(
           todo.isDone ? Icons.check_box : Icons.check_box_outline_blank,
-          color: tdBlue,
         ),
         title: Text(
           todo.todoText!,
           style: TextStyle(
             fontSize: 16,
-            color: tdBlack,
             decoration: todo.isDone ? TextDecoration.lineThrough : null,
           ),
         ),
@@ -46,16 +42,11 @@ class ToDoItem extends StatelessWidget {
           margin: const EdgeInsets.symmetric(vertical: 12),
           height: 35,
           width: 35,
-          decoration: BoxDecoration(
-            color: tdRed,
-            borderRadius: BorderRadius.circular(5),
-          ),
           child: IconButton(
-            color: Colors.white,
+            tooltip: 'delete todo',
             iconSize: 18,
             icon: const Icon(Icons.delete),
             onPressed: () {
-              // print('Clicked on delete icon');
               onDeleteItem(todo.id);
             },
           ),

--- a/task_nest/test/widget_test.dart
+++ b/task_nest/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:task_nest/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const TaskNest());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
Fixes #2  
## Changes proposed in this pull request

- Add a theme_button class to build the theme button
- Add a theme toggle button in the appBar, each time the theme toggling button is pressed it changes the from light to dark or from dark to light.
- Add default app color that will be used across all the app and it's components

## Refactoring
Some code refactoring was done for this feature to work and fine here they are listed.

- Changed the class name in main.dart from the default to TaskNest and make it extend StatefulWidget instead of StatelessWidget.
-  The components(Search bar, Add todo bar, etc...) and the text in them were not blending well with the app as they had a color originally assigned to them in the code, and this wasn't updating with the app's theme changing so this was removed so that it uses the default but, doing this made the components to fade into the screen and not be seen so they needed an elevation and since the Container widget they were originally using didn't take an elevation parameter I changed this to a Card widget so elevation can be used on them and make them more visible.